### PR TITLE
wptserve.py should send JSON failure message with correct mime type.

### DIFF
--- a/wptserve/response.py
+++ b/wptserve/response.py
@@ -209,7 +209,7 @@ class Response(object):
                "message": message}
         data = json.dumps({"error": err})
         self.status = code
-        self.headers = [("Content-Type", "text/json"),
+        self.headers = [("Content-Type", "application/json"),
                         ("Content-Length", len(data))]
         self.content = data
         if code == 500:


### PR DESCRIPTION
According to the JSON RFC [1](http://www.ietf.org/rfc/rfc4627.txt) the official mime type is "application/json". If
we do not send this, Gecko will not fire the onload event for a frame trying to
load such a URL but will instead load an error page. Gecko bug discussion is
at [2](https://bugzilla.mozilla.org/show_bug.cgi?id=1201632).

Several service worker tests rely on loading 'fake' iframes that 404 but
contribute to the progress of the test by watching for the onload event.
